### PR TITLE
Les équipements du réseau ont aussi le droit d'avoir un parent !

### DIFF
--- a/inc/shinken.class.php
+++ b/inc/shinken.class.php
@@ -700,7 +700,7 @@ class PluginMonitoringShinken extends CommonDBTM {
          } else {
             $a_networkports = $networkPort->find("`itemtype`='".$data['itemtype']."'
                AND `items_id`='".$data['items_id']."'
-               AND `name`='vers_parent_shinken' LIMIT 1");
+               AND `name` LIKE '%vers_parent_shinken%' LIMIT 1");
          }
          foreach ($a_networkports as $data_n) {
             $networkports_id = $networkPort->getContact($data_n['id']);


### PR DESCRIPTION
Lors de la préparation des dépendances entre les hôtes, si un premier équipement réseau est connecté à un second via un port nommé "vers_parent_shinken", alors le second devient parent du premier.

Shinken supporte de multiples parents, mais dans la table MySQL on a droit qu'à une dependencies par hôte. Pour supporter cela il faudrait créer une nouvelle table et faire le lien avec des clés étrangères.
